### PR TITLE
fix: Handle existing username error on Google callback

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -2,6 +2,14 @@
 
 Keep up with the latest updates here :D
 
+## 2025-08-24
+
+### Fixed
+
+- Bug where saving profile on the google callback page loads indefinitely when username exists.
+
+---
+
 ## 2025-04-30
 
 ## Fixed

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -6,7 +6,7 @@ Keep up with the latest updates here :D
 
 ### Fixed
 
-- Bug where saving profile on the google callback page loads indefinitely when username exists.
+- Fixed profile saving loading indefinitely on Google callback page when username already exists ([#108](https://github.com/beatcode-official/client/pull/108)).
 
 ---
 

--- a/src/routes/(auth)/login/google/callback/+page.svelte
+++ b/src/routes/(auth)/login/google/callback/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import type { PageProps } from "./$types";
 
-    import { type Infer, superForm } from "sveltekit-superforms";
+    import { type Infer, setError, superForm } from "sveltekit-superforms";
     import { type RegisterWithGoogleData, RegisterWithGoogleSchema } from "$models/auth";
 
     import * as Card from "$components/ui/card";
@@ -28,7 +28,18 @@
                 onResult: async ({ result }) => {
                     if (result.type === "redirect") {
                         announce(result, "Account created successfully");
+                    } else if (result.type === "error") {
+                        isSubmitting = false;
+                    } else if (result.type === "failure") {
+                        const error = result.data.error;
+                        if (error && error.toLowerCase().includes("username")) {
+                            setError(registerForm, "username", error);
+                        }
+                        isSubmitting = false;
                     }
+                },
+                onError: () => {
+                    isSubmitting = false;
                 }
             });
         }


### PR DESCRIPTION
The google callback page would load indefinitely when a user tried to save a profile with a username that already existed. This was because the frontend was not handling the error response from the backend.

This commit fixes the issue by updating the `onResult` and adding an `onError` callback to the `superForm` instance on the google callback page. The `onResult` callback now handles the `failure` case and displays an error message on the username field. The `isSubmitting` state is also reset correctly, preventing the form from hanging.

Also, updated the changelog.